### PR TITLE
fix: change percent was based on CP of single stock

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,14 +20,14 @@ function submitHandler() {
 function calculateProfitAndLoss(initial, quantity, current) {
   if (initial > current) {
     var loss = (initial - current) * quantity;
-    var lossPercentage = (loss / initial) * 100;
+    var lossPercentage = (loss / (initial * quantity)) * 100;
 
     showOutput(
       `Hey, the loss is ${loss} and the percent is ${lossPercentage}%`
     );
   } else if (current > initial) {
     var profit = (current - initial) * quantity;
-    var profitPercentage = (profit / initial) * 100;
+    var profitPercentage = (profit / (initial * quantity)) * 100;
 
     showOutput(
       `Hey, the profit is ${profit} and the percent is ${profitPercentage}%`


### PR DESCRIPTION
The profit and loss percentages were based on the CP of a single stock, and not the actual CP, which was the purchase price for 'n' number of stocks, resulting in incorrect values.